### PR TITLE
Twitter API v2

### DIFF
--- a/application.properties
+++ b/application.properties
@@ -5,6 +5,7 @@ homepage.url=http://localhost:8080
 
 twitter.consumer.key=
 twitter.consumer.secret=
+twitter.oauth2.client.id=
 
 mastodon.instance=
 mastodon.client.id=

--- a/pom.xml
+++ b/pom.xml
@@ -163,12 +163,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.github.scribejava</groupId>
-            <artifactId>scribejava-apis</artifactId>
-            <version>8.3.2</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
             <version>2.17.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,12 @@
         <dependency>
             <groupId>org.twitter4j</groupId>
             <artifactId>twitter4j-core</artifactId>
-            <version>4.1.2</version>
+            <version>4.0.7</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.takke</groupId>
+            <artifactId>jp.takke.twitter4j-v2</artifactId>
+            <version>1.4.1</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/nz/gen/wellington/rsstotwitter/controllers/LoggedInUserFilter.java
+++ b/src/main/java/nz/gen/wellington/rsstotwitter/controllers/LoggedInUserFilter.java
@@ -52,7 +52,7 @@ public class LoggedInUserFilter {
     }
 
     private boolean isAccountContentedToTwitter(Account account) {
-        return account.getToken() != null && account.getTokenSecret() != null;
+        return account.getTwitterAccessToken() != null && account.getTwitterRefreshToken() != null;
     }
 
 }

--- a/src/main/java/nz/gen/wellington/rsstotwitter/controllers/signin/TwitterCredentials.java
+++ b/src/main/java/nz/gen/wellington/rsstotwitter/controllers/signin/TwitterCredentials.java
@@ -1,14 +1,14 @@
 package nz.gen.wellington.rsstotwitter.controllers.signin;
 
-import com.github.scribejava.core.model.OAuth1AccessToken;
+import twitter4j.AccessToken;
 import twitter4j.v1.User;
 
 public class TwitterCredentials {
 
     private final User user;
-    private final OAuth1AccessToken token;
+    private final AccessToken token;
 
-    public TwitterCredentials(User user, OAuth1AccessToken token) {
+    public TwitterCredentials(User user, AccessToken token) {
         this.user = user;
         this.token = token;
     }
@@ -17,7 +17,7 @@ public class TwitterCredentials {
         return user;
     }
 
-    public OAuth1AccessToken getToken() {
+    public AccessToken getToken() {
         return token;
     }
 }

--- a/src/main/java/nz/gen/wellington/rsstotwitter/controllers/signin/TwitterCredentials.java
+++ b/src/main/java/nz/gen/wellington/rsstotwitter/controllers/signin/TwitterCredentials.java
@@ -1,23 +1,22 @@
 package nz.gen.wellington.rsstotwitter.controllers.signin;
 
-import twitter4j.AccessToken;
-import twitter4j.v1.User;
+import twitter4j.User2;
 
 public class TwitterCredentials {
 
-    private final User user;
-    private final AccessToken token;
+    private final User2 user;
+    private final String token;
 
-    public TwitterCredentials(User user, AccessToken token) {
+    public TwitterCredentials(User2 user, String token) {
         this.user = user;
         this.token = token;
     }
 
-    public User getUser() {
+    public User2 getUser() {
         return user;
     }
 
-    public AccessToken getToken() {
+    public String getToken() {
         return token;
     }
 }

--- a/src/main/java/nz/gen/wellington/rsstotwitter/controllers/signin/TwitterCredentials.java
+++ b/src/main/java/nz/gen/wellington/rsstotwitter/controllers/signin/TwitterCredentials.java
@@ -6,10 +6,12 @@ public class TwitterCredentials {
 
     private final User2 user;
     private final String token;
+    private final String refreshToken;
 
-    public TwitterCredentials(User2 user, String token) {
+    public TwitterCredentials(User2 user, String token, String refreshToken) {
         this.user = user;
         this.token = token;
+        this.refreshToken = refreshToken;
     }
 
     public User2 getUser() {
@@ -18,5 +20,9 @@ public class TwitterCredentials {
 
     public String getToken() {
         return token;
+    }
+
+    public String getRefreshToken() {
+        return refreshToken;
     }
 }

--- a/src/main/java/nz/gen/wellington/rsstotwitter/controllers/signin/TwitterSigninHandler.java
+++ b/src/main/java/nz/gen/wellington/rsstotwitter/controllers/signin/TwitterSigninHandler.java
@@ -56,12 +56,13 @@ public class TwitterSigninHandler implements SigninHandler<TwitterCredentials> {
             try {
                 OAuth2TokenProvider.Result result = twitterService.getOAuth2Token(code, callbackUrl);
                 String accessToken = result.getAccessToken();
+                String refreshToken = result.getRefreshToken();
                 log.info("Got access token " + accessToken);
 
                 log.info("Using access token to lookup twitter user details");
                 UsersResponse twitterUserResponse = twitterService.getTwitterUserCredentials(accessToken);
                 if (twitterUserResponse != null && !twitterUserResponse.getUsers().isEmpty()) {
-                    return new TwitterCredentials(twitterUserResponse.getUsers().get(0), accessToken);
+                    return new TwitterCredentials(twitterUserResponse.getUsers().get(0), accessToken, refreshToken);
 
                 } else {
                     log.warn("Failed up obtain twitter user details");
@@ -87,8 +88,8 @@ public class TwitterSigninHandler implements SigninHandler<TwitterCredentials> {
     public void decorateUserWithExternalSigninIdentifier(Account account, TwitterCredentials externalIdentifier) {
         account.setId(externalIdentifier.getUser().getId());
         account.setUsername(externalIdentifier.getUser().getScreenName());
-        account.setToken(externalIdentifier.getToken());
-        account.setTokenSecret(null);
+        account.setTwitterAccessToken(externalIdentifier.getToken());
+        account.setTwitterRefreshToken(externalIdentifier.getRefreshToken());
     }
 
 }

--- a/src/main/java/nz/gen/wellington/rsstotwitter/controllers/signin/TwitterSigninHandler.java
+++ b/src/main/java/nz/gen/wellington/rsstotwitter/controllers/signin/TwitterSigninHandler.java
@@ -1,6 +1,5 @@
 package nz.gen.wellington.rsstotwitter.controllers.signin;
 
-import com.google.common.collect.Maps;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import nz.gen.wellington.rsstotwitter.model.Account;
@@ -13,10 +12,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.view.RedirectView;
-import twitter4j.AccessToken;
-import twitter4j.RequestToken;
-
-import java.util.Map;
+import twitter4j.OAuth2TokenProvider;
+import twitter4j.UsersResponse;
 
 @Component
 public class TwitterSigninHandler implements SigninHandler<TwitterCredentials> {
@@ -28,8 +25,6 @@ public class TwitterSigninHandler implements SigninHandler<TwitterCredentials> {
 
     private final String callbackUrl;
 
-    private final Map<String, RequestToken> requestTokens;
-
     @Autowired
     public TwitterSigninHandler(AccountDAO accountDAO,
                                 TwitterService twitterService,
@@ -37,7 +32,6 @@ public class TwitterSigninHandler implements SigninHandler<TwitterCredentials> {
         this.accountDAO = accountDAO;
         this.twitterService = twitterService;
 
-        this.requestTokens = Maps.newConcurrentMap();
         this.callbackUrl = homepageUrl + "/oauth/callback";
     }
 
@@ -48,67 +42,38 @@ public class TwitterSigninHandler implements SigninHandler<TwitterCredentials> {
             return null;
         }
 
-        try {
-            log.info("Getting request token for callback url: " + callbackUrl);
-            RequestToken requestToken = twitterService.oauthAuthentication().getOAuthRequestToken(callbackUrl);
-
-            if (requestToken != null) {
-                log.info("Got request token: " + requestToken.getToken());
-                requestTokens.put(requestToken.getToken(), requestToken);
-
-                final String authorizeUrl = requestToken.getAuthorizationURL();
-                log.info("Redirecting user to authorize url : " + authorizeUrl);
-                return new ModelAndView(new RedirectView(authorizeUrl));
-            }
-
-        } catch (Exception e) {
-            log.warn("Failed to obtain request token.", e);
-        }
-        return null;
+        final String authorizeUrl = twitterService.getAuthorizeUrl(callbackUrl);
+        log.info("Redirecting user to authorize url : " + authorizeUrl);
+        return new ModelAndView(new RedirectView(authorizeUrl));
     }
 
     @Override
     public TwitterCredentials getExternalUserIdentifierFromCallbackRequest(HttpServletRequest request) {
-        if (request.getParameter("oauth_token") != null && request.getParameter("oauth_verifier") != null) {
-            final String token = request.getParameter("oauth_token");
-            final String verifier = request.getParameter("oauth_verifier");
+        if (request.getParameter("code") != null) {
+            final String code = request.getParameter("code");
 
-            log.info("Looking for request token: " + token);
-            RequestToken requestToken = requestTokens.get(token);
-            if (requestToken != null) {
-                log.info("Found stored request token: " + requestToken.getToken());
+            log.info("Exchanging code " + code + " for access token");
+            try {
+                OAuth2TokenProvider.Result result = twitterService.getOAuth2Token(code, callbackUrl);
+                String accessToken = result.getAccessToken();
+                log.info("Got access token " + accessToken);
 
-                log.debug("Exchanging request token for access token");
-                try {
-                    AccessToken accessToken = twitterService.oauthAuthentication().getOAuthAccessToken(requestToken, verifier);
-                    if (accessToken != null) {
-                        log.info("Got access token: '" + accessToken.getToken() + "', '" + accessToken.getTokenSecret() + "'");
-                        requestTokens.remove(requestToken.getToken());
+                log.info("Using access token to lookup twitter user details");
+                UsersResponse twitterUserResponse = twitterService.getTwitterUserCredentials(accessToken);
+                if (twitterUserResponse != null && !twitterUserResponse.getUsers().isEmpty()) {
+                    return new TwitterCredentials(twitterUserResponse.getUsers().get(0), accessToken);
 
-                        log.debug("Using access token to lookup twitter user details");
-                        twitter4j.v1.User twitterUser = twitterService.getTwitterUserCredentials(accessToken.getToken(), accessToken.getTokenSecret());
-                        if (twitterUser != null) {
-                            return new TwitterCredentials(twitterUser, accessToken);
-
-                        } else {
-                            log.warn("Failed up obtain twitter user details");
-                        }
-
-                    } else {
-                        log.warn("Could not get access token for: " + requestToken.getToken());
-                    }
-
-                } catch (Exception e) {
-                    log.error(e);
-                    return null;
+                } else {
+                    log.warn("Failed up obtain twitter user details");
                 }
 
-            } else {
-                log.warn("Could not find request token for: " + token);
+            } catch (Exception e) {
+                log.error("Failed to obtain access token and get authed user", e);
+                return null;
             }
 
         } else {
-            log.error("oauth token or verifier missing from callback request");
+            log.error("code missing from callback request");
         }
         return null;
     }
@@ -122,8 +87,8 @@ public class TwitterSigninHandler implements SigninHandler<TwitterCredentials> {
     public void decorateUserWithExternalSigninIdentifier(Account account, TwitterCredentials externalIdentifier) {
         account.setId(externalIdentifier.getUser().getId());
         account.setUsername(externalIdentifier.getUser().getScreenName());
-        account.setToken(externalIdentifier.getToken().getToken());
-        account.setTokenSecret(externalIdentifier.getToken().getTokenSecret());
+        account.setToken(externalIdentifier.getToken());
+        account.setTokenSecret(null);
     }
 
 }

--- a/src/main/java/nz/gen/wellington/rsstotwitter/model/Account.java
+++ b/src/main/java/nz/gen/wellington/rsstotwitter/model/Account.java
@@ -16,8 +16,8 @@ public class Account {
     private Long id;
     // This user's Twitter screen name
     private String username;
-    private String token;
-    private String tokenSecret;
+    private String twitterAccessToken;
+    private String twitterRefreshToken;
 
     private Long mastodonId;
     private String mastodonUsername;
@@ -48,20 +48,20 @@ public class Account {
         this.username = username;
     }
 
-    public String getToken() {
-        return token;
+    public String getTwitterAccessToken() {
+        return twitterAccessToken;
     }
 
-    public void setToken(String token) {    // TODO rename to accessToken
-        this.token = token;
+    public void setTwitterAccessToken(String twitterAccessToken) {    // TODO rename to accessToken
+        this.twitterAccessToken = twitterAccessToken;
     }
 
-    public String getTokenSecret() {    // TODO rename to accessTokenSecret
-        return tokenSecret;
+    public String getTwitterRefreshToken() {    // TODO rename to accessTokenSecret
+        return twitterRefreshToken;
     }
 
-    public void setTokenSecret(String tokenSecret) {
-        this.tokenSecret = tokenSecret;
+    public void setTwitterRefreshToken(String twitterRefreshToken) {
+        this.twitterRefreshToken = twitterRefreshToken;
     }
 
     public Long getMastodonId() {

--- a/src/main/java/nz/gen/wellington/rsstotwitter/repositories/mongo/TwitterHistoryDAO.java
+++ b/src/main/java/nz/gen/wellington/rsstotwitter/repositories/mongo/TwitterHistoryDAO.java
@@ -23,7 +23,7 @@ public class TwitterHistoryDAO {
         this.dataStoreFactory = dataStoreFactory;
     }
 
-    public boolean hasAlreadyBeenTweeted(Account account, String guid, Destination destination) {
+    public boolean hasAlreadyBeenPublished(Account account, String guid, Destination destination) {
         return !tweetsForGuid(account, guid, destination).isEmpty();
     }
 

--- a/src/main/java/nz/gen/wellington/rsstotwitter/twitter/TwitterService.java
+++ b/src/main/java/nz/gen/wellington/rsstotwitter/twitter/TwitterService.java
@@ -7,19 +7,14 @@ import nz.gen.wellington.rsstotwitter.model.Account;
 import nz.gen.wellington.rsstotwitter.model.Tweet;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import twitter4j.OAuthAuthorization;
-import twitter4j.Twitter;
-import twitter4j.TwitterException;
-import twitter4j.v1.Status;
-import twitter4j.v1.StatusUpdate;
-
-import java.time.LocalDateTime;
-import java.time.ZoneId;
+import twitter4j.*;
+import twitter4j.auth.OAuth2Authorization;
+import twitter4j.auth.OAuth2Token;
+import twitter4j.conf.Configuration;
+import twitter4j.conf.ConfigurationBuilder;
 
 @Component
 public class TwitterService {
@@ -28,21 +23,67 @@ public class TwitterService {
 
     private final String consumerKey;
     private final String consumerSecret;
+    private final String clientId;
 
     private final Counter tweetedCounter;
 
     @Autowired
     public TwitterService(@Value("${twitter.consumer.key}") String consumerKey,
                           @Value("${twitter.consumer.secret}") String consumerSecret,
+                          @Value("${twitter.oauth2.client.id}") String clientId,
                           MeterRegistry meterRegistry) {
         this.consumerKey = consumerKey;
         this.consumerSecret = consumerSecret;
+        this.clientId = clientId;
         this.tweetedCounter = meterRegistry.counter("tweeted");
+    }
+
+    public String getAuthorizeUrl(String callbackUrl) {
+        twitter4j.conf.ConfigurationBuilder cb = new twitter4j.conf.ConfigurationBuilder().
+                setOAuthConsumerKey(consumerKey).
+                setOAuthConsumerSecret(consumerSecret);
+
+        OAuth2TokenProvider oAuth2TokenProvider = new OAuth2TokenProvider(cb.build());
+        String[] writeScopes = {"tweet.read", "users.read", "tweet.write", "offline.access"};
+        return oAuth2TokenProvider.createAuthorizeUrl(
+                clientId,
+                callbackUrl,
+                writeScopes,
+                "challenge"
+        );
+    }
+
+    public OAuth2TokenProvider.Result getOAuth2Token(String code, String callbackUrl) {
+        twitter4j.conf.ConfigurationBuilder cb = new twitter4j.conf.ConfigurationBuilder().
+                setDebugEnabled(true).
+                setOAuthConsumerKey(consumerKey).
+                setOAuthConsumerSecret(consumerSecret);
+
+        OAuth2TokenProvider oAuth2TokenProvider = new OAuth2TokenProvider(cb.build());
+
+        return oAuth2TokenProvider.getAccessToken(clientId, callbackUrl, code, "challenge");
+    }
+
+    public UsersResponse getTwitterUserCredentials(String accessToken) {
+        try {
+            Twitter twitterApi = getAuthenticatedApiForAccessToken(accessToken);
+            final TwitterV2 v2 = TwitterV2ExKt.getV2(twitterApi);
+            return v2.getMe("",
+                    V2DefaultFields.tweetFields,
+                    V2DefaultFields.userFields
+            );
+
+        } catch (TwitterException e) {
+            log.warn("Failed up obtain twitter user details due to Twitter exception: " + e.getMessage());
+            return null;
+        }
     }
 
     public Tweet tweet(Tweet tweet, Account account) {
         log.info("Attempting to tweet: " + tweet.getText());
         final Twitter twitterApiForAccount = getAuthenticatedApiForAccount(account);
+        throw new UnsupportedOperationException();
+        /*
         try {
             final Status status = updateStatus(twitterApiForAccount, tweet);
             tweetedCounter.increment();
@@ -55,42 +96,22 @@ public class TwitterService {
         } catch (TwitterException e) {
             log.warn("A TwitterException occurred while trying to tweet: " + e.getMessage());
         }
-        return null;
-    }
-
-    public twitter4j.v1.User getTwitterUserCredentials(String accessTokenKey, String accessTokenSecret) {
-        Twitter twitterApi = getAuthenticatedApiForAccessToken(accessTokenKey, accessTokenSecret);
-        try {
-            return twitterApi.v1().users().verifyCredentials();
-
-        } catch (TwitterException e) {
-            log.warn("Failed up obtain twitter user details due to Twitter exception: " + e.getMessage());
-            return null;
-        }
-    }
-
-    public OAuthAuthorization oauthAuthentication() {
-        return OAuthAuthorization.newBuilder().oAuthConsumer(consumerKey, consumerSecret).build();
-    }
-
-    private Status updateStatus(Twitter twitter, Tweet tweet) throws TwitterException {
-        StatusUpdate statusUpdate = StatusUpdate.of(tweet.getText());
-        return twitter.v1().tweets().updateStatus(statusUpdate);
+        */
     }
 
     private Twitter getAuthenticatedApiForAccount(Account account) {
-        Twitter twitterApiForAccount = getAuthenticatedApiForAccessToken(account.getToken(), account.getTokenSecret());
+        Twitter twitterApiForAccount = getAuthenticatedApiForAccessToken(account.getToken());
         if (twitterApiForAccount == null) {
             throw new RuntimeException("Could not get api instance for account: " + account.getUsername());    // TODO is a null return really what twitter4j returns?
         }
         return twitterApiForAccount;
     }
 
-    private Twitter getAuthenticatedApiForAccessToken(String accessKeyToken, String accessKeySecret) {
-        return Twitter.newBuilder().
-                oAuthConsumer(consumerKey, consumerSecret).
-                oAuthAccessToken(accessKeyToken, accessKeySecret).
-                build();
+    private Twitter getAuthenticatedApiForAccessToken(String accessToken) {
+        Configuration conf = new ConfigurationBuilder().build();
+        OAuth2Authorization oAuth2Authorization = new OAuth2Authorization(conf);
+        oAuth2Authorization.setOAuth2Token(new OAuth2Token("bearer", accessToken));
+        return new TwitterFactory(conf).getInstance(oAuth2Authorization);
     }
 
     public boolean isConfigured() {

--- a/src/main/java/nz/gen/wellington/rsstotwitter/twitter/TwitterService.java
+++ b/src/main/java/nz/gen/wellington/rsstotwitter/twitter/TwitterService.java
@@ -1,8 +1,5 @@
 package nz.gen.wellington.rsstotwitter.twitter;
 
-import com.github.scribejava.apis.TwitterApi;
-import com.github.scribejava.core.builder.ServiceBuilder;
-import com.github.scribejava.core.oauth.OAuth10aService;
 import com.google.common.base.Strings;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -15,6 +12,7 @@ import org.joda.time.DateTimeZone;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import twitter4j.OAuthAuthorization;
 import twitter4j.Twitter;
 import twitter4j.TwitterException;
 import twitter4j.v1.Status;
@@ -71,10 +69,8 @@ public class TwitterService {
         }
     }
 
-    public OAuth10aService makeOauthService(String callBackUrl) {
-        log.info("Building oauth service with consumer key and consumer secret: " + consumerKey + ":" + consumerSecret);
-        log.info("Oauth callback url is: " + callBackUrl);
-        return new ServiceBuilder(consumerKey).apiSecret(consumerSecret).callback(callBackUrl).build(TwitterApi.instance());
+    public OAuthAuthorization oauthAuthentication() {
+        return OAuthAuthorization.newBuilder().oAuthConsumer(consumerKey, consumerSecret).build();
     }
 
     private Status updateStatus(Twitter twitter, Tweet tweet) throws TwitterException {

--- a/src/main/java/nz/gen/wellington/rsstotwitter/twitter/TwitterService.java
+++ b/src/main/java/nz/gen/wellington/rsstotwitter/twitter/TwitterService.java
@@ -108,7 +108,7 @@ public class TwitterService {
 
 
     private Twitter getAuthenticatedApiForAccount(Account account) {
-        Twitter twitterApiForAccount = getAuthenticatedApiForAccessToken(account.getToken());
+        Twitter twitterApiForAccount = getAuthenticatedApiForAccessToken(account.getTwitterAccessToken());
         if (twitterApiForAccount == null) {
             throw new RuntimeException("Could not get api instance for account: " + account.getUsername());    // TODO is a null return really what twitter4j returns?
         }

--- a/src/main/java/nz/gen/wellington/rsstotwitter/twitter/TwitterUpdater.java
+++ b/src/main/java/nz/gen/wellington/rsstotwitter/twitter/TwitterUpdater.java
@@ -74,13 +74,13 @@ public class TwitterUpdater {
                 if (tweet != null) {
                     Tweet updatedStatus = null;
                     if (destination == Destination.TWITTER) {
-                        if (isAccountContentedToTwitter(account)) {
+                        if (isAccountConnectedToTwitter(account)) {
                             log.info("Tweeting: " + tweet.getText());
                             updatedStatus = twitterService.tweet(tweet, account);
                         }
                     }
                     if (destination == Destination.MASTODON) {
-                        if (isAccountConnectedToMastdon(account)) {
+                        if (isAccountConnectedToMastodon(account)) {
                             log.info("Tooting: " + tweet.getText());
                             updatedStatus = mastodonService.post(account.getMastodonAccessToken(), tweet.getText());
                             // Mastodon statuses are returned as HTML; step down to plain text
@@ -132,12 +132,12 @@ public class TwitterUpdater {
         return new DateTime(feedItem.getPublishedDate()).isAfter(sevenDaysAgo);
     }
 
-    private boolean isAccountConnectedToMastdon(Account account) {
+    private boolean isAccountConnectedToMastodon(Account account) {
         return account.getMastodonAccessToken() != null;
     }
 
-    private boolean isAccountContentedToTwitter(Account account) {
-        return account.getToken() != null && account.getTokenSecret() != null;
+    private boolean isAccountConnectedToTwitter(Account account) {
+        return account.getToken() != null;
     }
 
 }

--- a/src/main/java/nz/gen/wellington/rsstotwitter/twitter/TwitterUpdater.java
+++ b/src/main/java/nz/gen/wellington/rsstotwitter/twitter/TwitterUpdater.java
@@ -137,7 +137,7 @@ public class TwitterUpdater {
     }
 
     private boolean isAccountConnectedToTwitter(Account account) {
-        return account.getToken() != null;
+        return account.getTwitterAccessToken() != null;
     }
 
 }

--- a/src/test/java/nz/gen/wellington/rsstotwitter/repositories/mongo/TwitterHistoryDAOTest.java
+++ b/src/test/java/nz/gen/wellington/rsstotwitter/repositories/mongo/TwitterHistoryDAOTest.java
@@ -38,10 +38,10 @@ public class TwitterHistoryDAOTest {
 
         twitterHistoryDAO.markAsTweeted(account, feedItem, tweet, Destination.TWITTER);
 
-        assertTrue(twitterHistoryDAO.hasAlreadyBeenTweeted(account, link, Destination.TWITTER));
-        assertFalse(twitterHistoryDAO.hasAlreadyBeenTweeted(account, "http://localhost/not-seen-before", Destination.TWITTER));
-        assertFalse(twitterHistoryDAO.hasAlreadyBeenTweeted(account, link, Destination.MASTODON));
-        assertFalse(twitterHistoryDAO.hasAlreadyBeenTweeted(anotherAccount, link, Destination.TWITTER));
+        assertTrue(twitterHistoryDAO.hasAlreadyBeenPublished(account, link, Destination.TWITTER));
+        assertFalse(twitterHistoryDAO.hasAlreadyBeenPublished(account, "http://localhost/not-seen-before", Destination.TWITTER));
+        assertFalse(twitterHistoryDAO.hasAlreadyBeenPublished(account, link, Destination.MASTODON));
+        assertFalse(twitterHistoryDAO.hasAlreadyBeenPublished(anotherAccount, link, Destination.TWITTER));
     }
 
 }

--- a/src/test/java/nz/gen/wellington/rsstotwitter/twitter/TwitterUpdaterTest.java
+++ b/src/test/java/nz/gen/wellington/rsstotwitter/twitter/TwitterUpdaterTest.java
@@ -68,6 +68,7 @@ public class TwitterUpdaterTest {
     @Test
     public void shouldTweetFeedItems() throws IOException {
         when(tweetFromFeedItemBuilder.buildTweetFromFeedItem(feedItem)).thenReturn(tweetToSend);
+        when(twitterService.isReadyToPublishFor(account)).thenReturn(true);
         when(twitterService.tweet(tweetToSend, account)).thenReturn(sentTweet);
 
         service.updateFeed(account, feed, feedItems, Destination.TWITTER);

--- a/src/test/java/nz/gen/wellington/rsstotwitter/twitter/TwitterUpdaterTest.java
+++ b/src/test/java/nz/gen/wellington/rsstotwitter/twitter/TwitterUpdaterTest.java
@@ -50,8 +50,8 @@ public class TwitterUpdaterTest {
         feedItem = new FeedItem(feed, "title", "guid", "link", Calendar.getInstance().getTime(), "author", null);
         feedItems = Lists.newArrayList(feedItem);
 
-        account.setToken("a-connected-twitter-token");
-        account.setTokenSecret("a-connected-twitter-token-secret");
+        account.setTwitterAccessToken("a-connected-twitter-token");
+        account.setTwitterRefreshToken("a-connected-twitter-token-secret");
 
         service = new TwitterUpdater(twitterHistoryDAO, twitterService, tweetFromFeedItemBuilder, mastodonService);
     }


### PR DESCRIPTION
Twitter finally disabled our v1 API access. Quick and dirty move to v2.

Update sign in flow to obtain an OAuth 2 access token.
Update Tweet call to use the v2 end point.
Fairly ugly placement of code to use the OAuth 2 refresh token to update the OAuth 2 access token which only lives for 2 hours.

